### PR TITLE
add vert_mtr to the output of get_race_history

### DIFF
--- a/pcs_scraper/rider.py
+++ b/pcs_scraper/rider.py
@@ -114,7 +114,7 @@ class Rider:
             pd.DataFrame: columns = ['date', 'result', 
                                      'race_name', 'race_href', 'race_pcs_name', 'race_pcs_year',
                                      'classification', 'distance', 
-                                     'pcs_points', 'uci_points']
+                                     'pcs_points', 'uci_points', 'vert_mtr']
         """
         
         # set the kwargs
@@ -282,7 +282,7 @@ class Rider:
                                      columns = ['date', 'result', 
                                                 'race_name', 'race_href', 'race_pcs_name', 'race_pcs_year',
                                                 'classification', 'distance', 
-                                                'pcs_points', 'uci_points'])
+                                                'pcs_points', 'uci_points', 'vert_mtr'])
 
 
         return results_frame


### PR DESCRIPTION
`get_race_history()` was not working anymore because there is a new column "Vert. mtr" in the table from the website:

https://www.procyclingstats.com/rider.php?xseason=&zxseason=&pxseason=equal&sort=date&race=&km1=&zkm1=&pkm1=equal&limit=200&topx=&ztopx=&ptopx=smallerorequal&type=&znation=&continent=&pnts=&zpnts=&ppnts=equal&level=&rnk=&zrnk=&prnk=equal&exclude_tt=0&racedate=&zracedate=&pracedate=equal&name=&pname=contains&category=&profile_score=&pprofile_score=largerorequal&filter=Filter&id=tadej-pogacar&p=results